### PR TITLE
fix(serpent): expand CBC chunk buffer to fit PKCS7-padded 65536-byte blocks

### DIFF
--- a/.github/workflows/npm-remove.yml
+++ b/.github/workflows/npm-remove.yml
@@ -1,0 +1,66 @@
+name: npm-remove
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to remove (e.g. v2.0.0)'
+        required: true
+        type: string
+      action:
+        description: 'Action'
+        required: true
+        type: choice
+        options:
+          - deprecate
+          - unpublish
+      message:
+        description: 'Deprecation message (deprecate only)'
+        required: false
+        default: 'Security: this version contains a critical bug. Upgrade to the latest release.'
+        type: string
+permissions:
+  contents: read
+jobs:
+  remove:
+    runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      PKG: leviathan-crypto
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: token_check
+        run: |
+          npm config set //registry.npmjs.org/:_authToken "$NODE_AUTH_TOKEN"
+          npm whoami
+
+      - name: version_check
+        run: |
+          VERSION="${{ inputs.version }}"
+          BARE="${VERSION#v}"
+          echo "BARE=${BARE}" >> "$GITHUB_ENV"
+          npm view "${PKG}@${BARE}" version
+
+      - name: unpublish_check
+        if: inputs.action == 'unpublish'
+        run: |
+          PUBLISHED=$(npm view "${PKG}@${BARE}" time --json | jq -r ".\"${BARE}\"")
+          PUBLISHED_TS=$(date -d "$PUBLISHED" +%s)
+          NOW_TS=$(date +%s)
+          AGE_HOURS=$(( (NOW_TS - PUBLISHED_TS) / 3600 ))
+          echo "Version ${BARE} published ${AGE_HOURS}h ago"
+          if [ "$AGE_HOURS" -ge 72 ]; then
+            echo "Outside 72-hour unpublish window (${AGE_HOURS}h >= 72h)"
+            exit 1
+          fi
+
+      - name: npm_run
+        env:
+          MSG: ${{ inputs.message }}
+        run: |
+          if [ "${{ inputs.action }}" = "unpublish" ]; then
+            npm unpublish "${PKG}@${BARE}"
+          else
+            npm deprecate "${PKG}@${BARE}" "$MSG"
+          fi

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,44 @@
 # Changelog
 
+## v2.0.1 (2026-04-10)
+
+### Security
+
+- **Silent data corruption in SerpentCipher pool.** `SealStreamPool` with
+  `SerpentCipher` and `chunkSize: 65536` silently produced corrupt plaintext
+  on decrypt for inputs >= 65536 bytes. The Serpent WASM CBC chunk buffer was
+  sized at 65536 bytes, but PKCS7 on a full 65536-byte chunk always appends a
+  full 16-byte padding block, producing a 65552-byte write. The 16-byte
+  overflow clobbered adjacent WASM memory. Auth passed, output was wrong,
+  and no error was raised. Fixed by expanding the WASM chunk buffers and all
+  downstream offsets to accommodate the PKCS7 maximum.
+
+### Changed
+
+- **`CipherSuite` interface adds `wasmChunkSize`.** Replaces a throwaway WASM
+  probe instantiation in `SealStreamPool.create()` with a static field.
+  `SerpentCipher`: 65552. `XChaCha20Cipher`: 65536. `KyberSuite` forwards
+  from its inner cipher.
+
+- **`SealStreamPool.create()` validates padded chunk size statically.** For
+  padded ciphers, pool creation now checks `paddedFull <= cipher.wasmChunkSize`
+  at startup and throws a `RangeError` with the actual values if the check
+  fails. The old probe-based approach is removed.
+
+- **`cbcEncryptChunk` and `cbcDecryptChunk` return codes checked.** Both pool
+  worker and `SerpentCbc` now inspect the WASM return value and throw a
+  `RangeError` on rejection instead of silently reading from a potentially
+  corrupt buffer region.
+
+### Test Suite
+
+- 582 unit tests (Vitest), 189 e2e tests (Playwright × 3 browsers), 771 total.
+- New test files: `serpent_large_pool.spec.ts` (3 × 3 browsers).
+  Covers `chunkSize: 65536` at 256 KB (4 full chunks), 5 MB (hash comparison),
+  and the specific regression: full chunks must not decrypt to zeros.
+
+---
+
 ## v2.0.0 (2026-04-10)
 
 ### Breaking Changes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,11 @@
 > - Pool workers copy result buffers.
 > - Scalar JS `constantTimeEqual` was "best-effort only".
 
+> [!WARNING]
+> **v2.0.0 known issue** (addressed in v2.0.1):
+> - `SealStreamPool` with `SerpentCipher` and `chunkSize: 65536` silently
+>   produces corrupt plaintext on decrypt for inputs >= 65536 bytes. No
+>   authentication error is raised. Upgrade to v2.0.1 immediately.
 
 ## Security Posture
 

--- a/docs/aead.md
+++ b/docs/aead.md
@@ -231,6 +231,9 @@ pool.destroy()
 | `framed` | `boolean` | `false` | Framed mode. |
 | `jobTimeout` | `number` | `30000` | Per-job timeout in ms. |
 
+> [!NOTE]
+> For padded ciphers (`SerpentCipher`), `create()` validates at startup that a full plaintext chunk fits in the WASM buffer after PKCS7 padding. If `chunkSize` is too large it throws a `RangeError` with the actual values before any workers are launched. The default `chunkSize: 65536` is valid for both built-in cipher suites.
+
 **Failure model.** Any error is fatal. Authentication failure, worker crash, and timeout all terminate every worker, wipe all keys, and mark the pool permanently dead. Pending promises reject. There is no retry and no worker replacement. Create a new pool for the next operation.
 
 | Method / Property | Description |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -752,11 +752,11 @@ Source: `src/asm/serpent/buffers.ts`
 | 64 | 16 | `NONCE_BUFFER` — CTR mode nonce |
 | 80 | 16 | `COUNTER_BUFFER` — 128-bit little-endian counter |
 | 96 | 528 | `SUBKEY_BUFFER` — key schedule output (33 rounds × 4 × 4 bytes) |
-| 624 | 65536 | `CHUNK_PT_BUFFER` — streaming plaintext (CTR/CBC) |
-| 66160 | 65536 | `CHUNK_CT_BUFFER` — streaming ciphertext (CTR/CBC) |
-| 131696 | 20 | `WORK_BUFFER` — 5 × i32 scratch registers (key schedule + S-box/LT rounds) |
-| 131716 | 16 | `CBC_IV_BUFFER` — CBC initialization vector / chaining value |
-| 131732 | — | END |
+| 624 | 65552 | `CHUNK_PT_BUFFER` — streaming plaintext (CTR/CBC); +16 from 65536 to fit PKCS7 max overhead |
+| 66176 | 65552 | `CHUNK_CT_BUFFER` — streaming ciphertext (CTR/CBC) |
+| 131728 | 20 | `WORK_BUFFER` — 5 × i32 scratch registers (key schedule + S-box/LT rounds) |
+| 131748 | 16 | `CBC_IV_BUFFER` — CBC initialization vector / chaining value |
+| 131856 | — | END |
 
 `wipeBuffers()` zeroes all 10 buffers (key, block pt/ct, nonce, counter, subkeys, work, chunk pt/ct, CBC IV).
 
@@ -902,8 +902,9 @@ They are the immutable truth, and must never be modified to make tests pass.
 - **Single-threaded WASM per instance**: one WASM instance per binary per thread.
   `SealStreamPool` provides Worker-based parallelism for both cipher families;
   other primitives remain single-threaded.
-- **Max input per WASM call**: chunk-based APIs (CTR, CBC) accept at most 64KB
-  per call. Wrappers handle splitting automatically for larger inputs.
+- **Max input per WASM call**: CTR accepts at most 65536 bytes per call; CBC
+  accepts at most 65552 bytes (65536 + 16 bytes PKCS7 maximum overhead).
+  Wrappers handle splitting automatically for larger inputs.
 - **WASM side-channel posture**: WebAssembly implementations offer the best
   available side-channel resistance (branchless, table-free), but lack
   hardware-level constant-time guarantees. For applications where timing

--- a/docs/asm_serpent.md
+++ b/docs/asm_serpent.md
@@ -121,21 +121,21 @@ function getNonceOffset(): i32     // 64
 function getCounterOffset(): i32   // 80
 function getSubkeyOffset(): i32    // 96
 function getChunkPtOffset(): i32   // 624
-function getChunkCtOffset(): i32   // 66160
-function getWorkOffset(): i32      // 131696
-function getCbcIvOffset(): i32     // 131716
+function getChunkCtOffset(): i32   // 66176
+function getWorkOffset(): i32      // 131728
+function getCbcIvOffset(): i32     // 131748
 ```
 Each returns the fixed byte offset for that buffer. Values shown as comments.
 
 ```typescript
-function getSimdWorkOffset(): i32  // 131744
+function getSimdWorkOffset(): i32  // 131776
 ```
 Returns the byte offset of `SIMD_WORK_BUFFER`. Five v128 working registers used by the SIMD S-box circuits. Only present when the binary is built with `--enable simd`.
 
 ```typescript
-function getChunkSize(): i32       // 65536
+function getChunkSize(): i32       // 65552
 ```
-Returns the maximum chunk size in bytes (64KB).
+Returns the maximum chunk size in bytes (65552 — 65536 + 16 bytes PKCS7 maximum overhead).
 
 ```typescript
 function getMemoryPages(): i32
@@ -210,7 +210,7 @@ counter range without calling `resetCounter()`.
 function encryptChunk(chunkLen: i32): i32
 ```
 CTR-encrypts `chunkLen` bytes from `CHUNK_PT_BUFFER` (offset 624) to
-`CHUNK_CT_BUFFER` (offset 66160). Handles partial final blocks (1-15 bytes)
+`CHUNK_CT_BUFFER` (offset 66176). Handles partial final blocks (1-15 bytes)
 natively; no padding required.
 
 - **chunkLen**: 1 to 65536
@@ -234,11 +234,11 @@ function cbcEncryptChunk(len: i32): i32
 ```
 CBC-encrypts `len` bytes from `CHUNK_PT_BUFFER` to `CHUNK_CT_BUFFER`.
 
-- **len**: must be a positive multiple of 16, at most 65536
+- **len**: must be a positive multiple of 16, at most 65552
 - **Returns**: `len` on success, `-1` if `len` is invalid
 
 Chaining: `C[i] = Encrypt(P[i] XOR C[i-1])`, where `C[-1]` is the IV stored at
-`CBC_IV_BUFFER` (offset 131716). The IV buffer is updated to the last ciphertext
+`CBC_IV_BUFFER` (offset 131748). The IV buffer is updated to the last ciphertext
 block on return, enabling streaming across multiple chunk calls.
 
 PKCS7 padding is the caller's responsibility (applied in the TypeScript wrapper).
@@ -248,7 +248,7 @@ function cbcDecryptChunk(len: i32): i32
 ```
 CBC-decrypts `len` bytes from `CHUNK_CT_BUFFER` to `CHUNK_PT_BUFFER`.
 
-- **len**: must be a positive multiple of 16, at most 65536
+- **len**: must be a positive multiple of 16, at most 65552
 - **Returns**: `len` on success, `-1` if `len` is invalid
 
 Chaining: `P[i] = Decrypt(C[i]) XOR C[i-1]`. The IV buffer is updated to the last
@@ -317,11 +317,11 @@ Zeroes all sensitive memory regions:
 | NONCE_BUFFER | 64 | 16 |
 | COUNTER_BUFFER | 80 | 16 |
 | SUBKEY_BUFFER | 96 | 528 |
-| CHUNK_PT_BUFFER | 624 | 65536 |
-| CHUNK_CT_BUFFER | 66160 | 65536 |
-| WORK_BUFFER | 131696 | 20 |
-| CBC_IV_BUFFER | 131716 | 16 |
-| SIMD_WORK_BUFFER | 131744 | 80 |
+| CHUNK_PT_BUFFER | 624 | 65552 |
+| CHUNK_CT_BUFFER | 66176 | 65552 |
+| WORK_BUFFER | 131728 | 20 |
+| CBC_IV_BUFFER | 131748 | 16 |
+| SIMD_WORK_BUFFER | 131776 | 80 |
 
 Must be called when done with the cipher (the TypeScript wrapper calls this in
 `dispose()`).
@@ -330,8 +330,8 @@ Must be called when done with the cipher (the TypeScript wrapper calls this in
 
 ## Buffer Layout
 
-All buffers are static, starting at offset 0. Total footprint: 131732 bytes
-(< 192KB = 3 x 64KB pages, with 64876 bytes spare).
+All buffers are static, starting at offset 0. Total footprint: 131856 bytes
+(< 192KB = 3 x 64KB pages, with 64752 bytes spare).
 
 | Offset | Size (bytes) | Name | Purpose |
 |--------|-------------|------|---------|
@@ -341,13 +341,13 @@ All buffers are static, starting at offset 0. Total footprint: 131732 bytes
 | 64 | 16 | `NONCE_BUFFER` | CTR nonce (initial counter value) |
 | 80 | 16 | `COUNTER_BUFFER` | 128-bit LE counter (CTR mode state) |
 | 96 | 528 | `SUBKEY_BUFFER` | Expanded subkeys: 33 rounds x 4 words x 4 bytes |
-| 624 | 65536 | `CHUNK_PT_BUFFER` | Bulk plaintext input (CTR/CBC) |
-| 66160 | 65536 | `CHUNK_CT_BUFFER` | Bulk ciphertext output (CTR/CBC) |
-| 131696 | 20 | `WORK_BUFFER` | 5 × i32 working registers for scalar S-box computation |
-| 131716 | 16 | `CBC_IV_BUFFER` | CBC chaining value (IV, then last CT block) |
-| 131732 | 12 | *(alignment padding)* | Pad to 16-byte boundary for v128 SIMD alignment |
-| 131744 | 80 | `SIMD_WORK_BUFFER` | 5 × v128 working registers for SIMD S-box computation |
-| 131824 | | `END` | Total < 196608 (3 pages) |
+| 624 | 65552 | `CHUNK_PT_BUFFER` | Bulk plaintext input (CTR/CBC); +16 from 65536 to fit PKCS7 max overhead |
+| 66176 | 65552 | `CHUNK_CT_BUFFER` | Bulk ciphertext output (CTR/CBC) |
+| 131728 | 20 | `WORK_BUFFER` | 5 × i32 working registers for scalar S-box computation |
+| 131748 | 16 | `CBC_IV_BUFFER` | CBC chaining value (IV, then last CT block) |
+| 131764 | 12 | *(alignment padding)* | Pad to 16-byte boundary for v128 SIMD alignment |
+| 131776 | 80 | `SIMD_WORK_BUFFER` | 5 × v128 working registers for SIMD S-box computation |
+| 131856 | | `END` | Total < 196608 (3 pages) |
 
 The `SUBKEY_BUFFER` holds 132 i32 words during key expansion, then the final 33 × 4
 round subkeys. The `WORK_BUFFER` holds 5 working registers (r0-r4) for the scalar
@@ -496,8 +496,8 @@ serpent_unrolled.ts     serpent_simd.ts
 | `loadKey(keyLen)` | `keyLen` is not 16, 24, or 32 | `-1` |
 | `encryptChunk(chunkLen)` | `chunkLen <= 0` or `chunkLen > 65536` | `-1` |
 | `decryptChunk(chunkLen)` | `chunkLen <= 0` or `chunkLen > 65536` | `-1` |
-| `cbcEncryptChunk(len)` | `len <= 0`, `len > 65536`, or `len % 16 !== 0` | `-1` |
-| `cbcDecryptChunk(len)` | `len <= 0`, `len > 65536`, or `len % 16 !== 0` | `-1` |
+| `cbcEncryptChunk(len)` | `len <= 0`, `len > 65552`, or `len % 16 !== 0` | `-1` |
+| `cbcDecryptChunk(len)` | `len <= 0`, `len > 65552`, or `len % 16 !== 0` | `-1` |
 
 > [!NOTE]
 > `encryptBlock`/`decryptBlock` have no error returns. They assume `loadKey`

--- a/docs/cdn.md
+++ b/docs/cdn.md
@@ -19,9 +19,9 @@ themselves.
 
 ```html
 <script type="module">
-  import { init, Seal, SerpentCipher } from 'https://unpkg.com/leviathan-crypto@2.0.0/dist/index.js'
-  import { serpentWasm } from 'https://unpkg.com/leviathan-crypto@2.0.0/dist/serpent/embedded.js'
-  import { sha2Wasm }    from 'https://unpkg.com/leviathan-crypto@2.0.0/dist/sha2/embedded.js'
+  import { init, Seal, SerpentCipher } from 'https://unpkg.com/leviathan-crypto@2.0.1/dist/index.js'
+  import { serpentWasm } from 'https://unpkg.com/leviathan-crypto@2.0.1/dist/serpent/embedded.js'
+  import { sha2Wasm }    from 'https://unpkg.com/leviathan-crypto@2.0.1/dist/sha2/embedded.js'
 
   await init({ serpent: serpentWasm, sha2: sha2Wasm })
 
@@ -37,8 +37,8 @@ Subpath imports also work with full URLs:
 
 ```html
 <script type="module">
-  import { serpentInit, SerpentCipher } from 'https://unpkg.com/leviathan-crypto@2.0.0/dist/serpent/index.js'
-  import { serpentWasm } from 'https://unpkg.com/leviathan-crypto@2.0.0/dist/serpent/embedded.js'
+  import { serpentInit, SerpentCipher } from 'https://unpkg.com/leviathan-crypto@2.0.1/dist/serpent/index.js'
+  import { serpentWasm } from 'https://unpkg.com/leviathan-crypto@2.0.1/dist/serpent/embedded.js'
 
   await serpentInit(serpentWasm)
   // ...
@@ -54,10 +54,10 @@ Pass a `URL` pointing at the `.wasm` file on the CDN. The browser uses
 
 ```html
 <script type="module">
-  import { init, SHA256 } from 'https://unpkg.com/leviathan-crypto@2.0.0/dist/index.js'
+  import { init, SHA256 } from 'https://unpkg.com/leviathan-crypto@2.0.1/dist/index.js'
 
   await init({
-    sha2: new URL('https://unpkg.com/leviathan-crypto@2.0.0/dist/sha2.wasm')
+    sha2: new URL('https://unpkg.com/leviathan-crypto@2.0.1/dist/sha2.wasm')
   })
 
   const sha    = new SHA256()
@@ -88,10 +88,10 @@ before instantiation.
 
 ```html
 <script type="module">
-  import { init, Seal, XChaCha20Cipher } from 'https://unpkg.com/leviathan-crypto@2.0.0/dist/index.js'
-  import { sha2Wasm } from 'https://unpkg.com/leviathan-crypto@2.0.0/dist/sha2/embedded.js'
+  import { init, Seal, XChaCha20Cipher } from 'https://unpkg.com/leviathan-crypto@2.0.1/dist/index.js'
+  import { sha2Wasm } from 'https://unpkg.com/leviathan-crypto@2.0.1/dist/sha2/embedded.js'
 
-  const res = await fetch('https://unpkg.com/leviathan-crypto@2.0.0/dist/chacha20.wasm', {
+  const res = await fetch('https://unpkg.com/leviathan-crypto@2.0.1/dist/chacha20.wasm', {
     // integrity hash is version-specific, update when upgrading
     integrity: 'sha384-...'
   })
@@ -123,16 +123,16 @@ If you want the same import style as the npm docs, add one before your module sc
 <script type="importmap">
 {
   "imports": {
-    "leviathan-crypto":                    "https://unpkg.com/leviathan-crypto@2.0.0/dist/index.js",
-    "leviathan-crypto/serpent":            "https://unpkg.com/leviathan-crypto@2.0.0/dist/serpent/index.js",
-    "leviathan-crypto/serpent/embedded":   "https://unpkg.com/leviathan-crypto@2.0.0/dist/serpent/embedded.js",
-    "leviathan-crypto/chacha20":           "https://unpkg.com/leviathan-crypto@2.0.0/dist/chacha20/index.js",
-    "leviathan-crypto/chacha20/embedded":  "https://unpkg.com/leviathan-crypto@2.0.0/dist/chacha20/embedded.js",
-    "leviathan-crypto/sha2":               "https://unpkg.com/leviathan-crypto@2.0.0/dist/sha2/index.js",
-    "leviathan-crypto/sha2/embedded":      "https://unpkg.com/leviathan-crypto@2.0.0/dist/sha2/embedded.js",
-    "leviathan-crypto/sha3":               "https://unpkg.com/leviathan-crypto@2.0.0/dist/sha3/index.js",
-    "leviathan-crypto/sha3/embedded":      "https://unpkg.com/leviathan-crypto@2.0.0/dist/sha3/embedded.js",
-    "leviathan-crypto/stream":             "https://unpkg.com/leviathan-crypto@2.0.0/dist/stream/index.js"
+    "leviathan-crypto":                    "https://unpkg.com/leviathan-crypto@2.0.1/dist/index.js",
+    "leviathan-crypto/serpent":            "https://unpkg.com/leviathan-crypto@2.0.1/dist/serpent/index.js",
+    "leviathan-crypto/serpent/embedded":   "https://unpkg.com/leviathan-crypto@2.0.1/dist/serpent/embedded.js",
+    "leviathan-crypto/chacha20":           "https://unpkg.com/leviathan-crypto@2.0.1/dist/chacha20/index.js",
+    "leviathan-crypto/chacha20/embedded":  "https://unpkg.com/leviathan-crypto@2.0.1/dist/chacha20/embedded.js",
+    "leviathan-crypto/sha2":               "https://unpkg.com/leviathan-crypto@2.0.1/dist/sha2/index.js",
+    "leviathan-crypto/sha2/embedded":      "https://unpkg.com/leviathan-crypto@2.0.1/dist/sha2/embedded.js",
+    "leviathan-crypto/sha3":               "https://unpkg.com/leviathan-crypto@2.0.1/dist/sha3/index.js",
+    "leviathan-crypto/sha3/embedded":      "https://unpkg.com/leviathan-crypto@2.0.1/dist/sha3/embedded.js",
+    "leviathan-crypto/stream":             "https://unpkg.com/leviathan-crypto@2.0.1/dist/stream/index.js"
   }
 }
 </script>

--- a/docs/ciphersuite.md
+++ b/docs/ciphersuite.md
@@ -21,6 +21,7 @@ either of them with an ML-KEM layer for hybrid post-quantum encryption.
 | `keySize`         | 32 bytes                       | 32 bytes                  |
 | `tagSize`         | 32 bytes                       | 16 bytes                  |
 | `padded`          | `true` (PKCS7)                 | `false`                   |
+| `wasmChunkSize`   | `65552`                        | `65536`                   |
 | `wasmModules`     | `['serpent', 'sha2']`          | `['chacha20', 'sha2']`    |
 | Auth construction | Encrypt-then-MAC               | AEAD                      |
 
@@ -106,14 +107,15 @@ are plain `const` objects. You can implement your own by satisfying the interfac
 
 ### Fields
 
-| Field         | Type                | Description                                                              |
-| ------------- | ------------------- | ------------------------------------------------------------------------ |
-| `formatEnum`  | `number`            | Wire format ID. Bits 0-5 of header byte 0. Max `0x3f`. Bit 6 reserved.   |
-| `hkdfInfo`    | `string`            | HKDF info string for domain separation between cipher suites.            |
-| `keySize`     | `number`            | Required master key length in bytes.                                     |
-| `tagSize`     | `number`            | Authentication tag size in bytes per chunk.                              |
-| `padded`      | `boolean`           | Whether ciphertext includes block padding. Affects pool chunk splitting. |
-| `wasmModules` | `readonly string[]` | WASM modules this suite requires.                                        |
+| Field           | Type                | Description                                                              |
+| --------------- | ------------------- | ------------------------------------------------------------------------ |
+| `formatEnum`    | `number`            | Wire format ID. Bits 0-5 of header byte 0. Max `0x3f`. Bit 6 reserved.   |
+| `hkdfInfo`      | `string`            | HKDF info string for domain separation between cipher suites.            |
+| `keySize`       | `number`            | Required master key length in bytes.                                     |
+| `tagSize`       | `number`            | Authentication tag size in bytes per chunk.                              |
+| `padded`        | `boolean`           | Whether ciphertext includes block padding. Affects pool chunk splitting. |
+| `wasmChunkSize` | `number`            | WASM buffer capacity for one padded chunk. Pool validates `paddedFull ≤ wasmChunkSize` at creation for padded ciphers. Must match the `CHUNK_SIZE` constant in the cipher's WASM module. |
+| `wasmModules`   | `readonly string[]` | WASM modules this suite requires.                                        |
 
 ### Methods
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -210,6 +210,7 @@ Cipher-specific logic injected into `SealStream` and `OpenStream`.
 | `kemCtSize` | `number` | KEM ciphertext byte length appended to the header in the preamble. `0` for symmetric suites |
 | `tagSize` | `number` | Authentication tag size in bytes |
 | `padded` | `boolean` | Whether ciphertext includes padding (PKCS7 for CBC) |
+| `wasmChunkSize` | `number` | WASM buffer capacity for one padded chunk. `SealStreamPool.create()` validates `paddedFull ≤ wasmChunkSize` at startup for padded ciphers and throws `RangeError` if the check fails. `SerpentCipher`: 65552. `XChaCha20Cipher`: 65536. `KyberSuite` forwards from its inner cipher. |
 | `wasmModules` | `readonly string[]` | Cipher-specific WASM modules used by pool workers and per-chunk operations (not transitive dependencies such as HKDF-SHA-256 used by `deriveKeys()`) |
 
 | Method | Signature | Description |

--- a/src/asm/serpent/buffers.ts
+++ b/src/asm/serpent/buffers.ts
@@ -24,7 +24,7 @@
 // Serpent module — static buffer layout.
 // Independent linear memory starting at offset 0.
 //
-// Total: 131824 bytes < 3 × 64KB = 196608 (64784 bytes spare).
+// Total: 131856 bytes < 3 × 64KB = 196608 (64752 bytes spare).
 //
 // Offset   Size     Name
 // 0        32       KEY_BUFFER (pad to 32 for all key sizes)
@@ -33,15 +33,15 @@
 // 64       16       NONCE_BUFFER (CTR mode)
 // 80       16       COUNTER_BUFFER (128-bit LE)
 // 96       528      SUBKEY_BUFFER (33 rounds × 4 words × 4 bytes)
-// 624      65536    CHUNK_PT_BUFFER
-// 66160    65536    CHUNK_CT_BUFFER
-// 131696   20       WORK_BUFFER (5 × i32 working registers)
-// 131716   16       CBC_IV_BUFFER
-// 131732   12       (padding for 16-byte SIMD alignment)
-// 131744   80       SIMD_WORK_BUFFER (5 × v128 working registers)
-// 131824            END (< 196608 = 3 × 64KB ✓)
+// 624      65552    CHUNK_PT_BUFFER   (+16 from 65536; accommodates PKCS7 max overhead)
+// 66176    65552    CHUNK_CT_BUFFER   (+16, start shifts +16)
+// 131728   20       WORK_BUFFER       (start shifts +32)
+// 131748   16       CBC_IV_BUFFER     (start shifts +32)
+// 131764   12       (alignment pad)
+// 131776   80       SIMD_WORK_BUFFER  (start shifts +32)
+// 131856            END               (< 196608 = 3 pages ✓)
 
-export const CHUNK_SIZE:       i32 = 65536;
+export const CHUNK_SIZE:       i32 = 65552;   // 65536 + 16 (PKCS7 max overhead)
 
 export const KEY_OFFSET:       i32 = 0;
 export const BLOCK_PT_OFFSET:  i32 = 32;
@@ -50,12 +50,12 @@ export const NONCE_OFFSET:     i32 = 64;
 export const COUNTER_OFFSET:   i32 = 80;
 export const SUBKEY_OFFSET:    i32 = 96;
 export const CHUNK_PT_OFFSET:  i32 = 624;
-export const CHUNK_CT_OFFSET:  i32 = 66160;
-export const WORK_OFFSET:      i32 = 131696;
-export const CBC_IV_OFFSET:    i32 = 131716;
-// 12 bytes padding for 16-byte alignment
-export const SIMD_WORK_OFFSET: i32 = 131744;  // 5 × v128 = 80 bytes
-// END = 131824 < 196608 ✓
+export const CHUNK_CT_OFFSET:  i32 = 66176;   // 624 + 65552
+export const WORK_OFFSET:      i32 = 131728;  // 66176 + 65552
+export const CBC_IV_OFFSET:    i32 = 131748;  // 131728 + 20
+// 12 bytes padding for 16-byte alignment (131748+16=131764, 131764+12=131776)
+export const SIMD_WORK_OFFSET: i32 = 131776;  // 5 × v128 = 80 bytes
+// END = 131856 < 196608 ✓
 
 export function getModuleId():      i32 {
 	return 0;

--- a/src/ts/chacha20/cipher-suite.ts
+++ b/src/ts/chacha20/cipher-suite.ts
@@ -45,6 +45,7 @@ export const XChaCha20Cipher: CipherSuite & { keygen(): Uint8Array } = {
 	kemCtSize: 0,
 	tagSize: 16,
 	padded: false,
+	wasmChunkSize: 65536,  // src/asm/chacha20/buffers.ts CHUNK_SIZE
 	wasmModules: ['chacha20'],
 
 	keygen(): Uint8Array {

--- a/src/ts/kyber/suite.ts
+++ b/src/ts/kyber/suite.ts
@@ -71,6 +71,7 @@ export function KyberSuite(
 		kemCtSize: p.ctBytes,
 		tagSize: inner.tagSize,
 		padded: inner.padded,
+		wasmChunkSize: inner.wasmChunkSize,
 		wasmModules: [...inner.wasmModules, 'kyber', 'sha3'],
 
 		deriveKeys(key: Uint8Array, nonce: Uint8Array, kemCt?: Uint8Array): DerivedKeys {

--- a/src/ts/serpent/cipher-suite.ts
+++ b/src/ts/serpent/cipher-suite.ts
@@ -42,6 +42,7 @@ export const SerpentCipher: CipherSuite & { keygen(): Uint8Array } = {
 	kemCtSize: 0,
 	tagSize: 32,
 	padded: true,
+	wasmChunkSize: 65552,  // src/asm/serpent/buffers.ts CHUNK_SIZE (65536 + 16 PKCS7 max overhead)
 	wasmModules: ['serpent', 'sha2'],
 
 	keygen(): Uint8Array {

--- a/src/ts/serpent/pool-worker.ts
+++ b/src/ts/serpent/pool-worker.ts
@@ -29,6 +29,7 @@ interface SerpentW {
 	getChunkPtOffset(): number;
 	getChunkCtOffset(): number;
 	getCbcIvOffset(): number;
+	getChunkSize(): number;
 	loadKey(n: number): number;
 	cbcEncryptChunk(n: number): number;
 	cbcDecryptChunk(n: number): number;
@@ -114,7 +115,11 @@ function cbcEncrypt(encKey: Uint8Array, iv: Uint8Array, plaintext: Uint8Array): 
 	mem.set(iv, s.getCbcIvOffset());
 	const padded = pkcs7Pad(plaintext);
 	mem.set(padded, s.getChunkPtOffset());
-	s.cbcEncryptChunk(padded.length);
+	const ret = s.cbcEncryptChunk(padded.length);
+	if (ret < 0) throw new RangeError(
+		`cbcEncryptChunk rejected len=${padded.length}` +
+		` (WASM CHUNK_SIZE=${s.getChunkSize()})`,
+	);
 	return new Uint8Array(s.memory.buffer).slice(s.getChunkCtOffset(), s.getChunkCtOffset() + padded.length);
 }
 
@@ -125,7 +130,11 @@ function cbcDecrypt(encKey: Uint8Array, iv: Uint8Array, ct: Uint8Array): Uint8Ar
 	s.loadKey(encKey.length);
 	mem.set(iv, s.getCbcIvOffset());
 	mem.set(ct, s.getChunkCtOffset());
-	s.cbcDecryptChunk(ct.length);
+	const ret = s.cbcDecryptChunk(ct.length);
+	if (ret < 0) throw new RangeError(
+		`cbcDecryptChunk rejected len=${ct.length}` +
+		` (WASM CHUNK_SIZE=${s.getChunkSize()})`,
+	);
 	const raw = new Uint8Array(s.memory.buffer).slice(s.getChunkPtOffset(), s.getChunkPtOffset() + ct.length);
 	return pkcs7Strip(raw);
 }

--- a/src/ts/serpent/serpent-cbc.ts
+++ b/src/ts/serpent/serpent-cbc.ts
@@ -117,7 +117,11 @@ export class SerpentCbc {
 		for (let off = 0; off < padded.length; off += maxChunk) {
 			const chunk = padded.subarray(off, Math.min(off + maxChunk, padded.length));
 			this.mem.set(chunk, ptOff);
-			this.x.cbcEncryptChunk(chunk.length);
+			const ret = this.x.cbcEncryptChunk(chunk.length);
+			if (ret < 0) throw new RangeError(
+				`cbcEncryptChunk rejected len=${chunk.length}` +
+				` (WASM CHUNK_SIZE=${this.x.getChunkSize()})`,
+			);
 			output.set(new Uint8Array(this.x.memory.buffer).subarray(ctOff, ctOff + chunk.length), off);
 		}
 		return output;
@@ -139,7 +143,11 @@ export class SerpentCbc {
 		for (let off = 0; off < ciphertext.length; off += maxChunk) {
 			const chunk = ciphertext.subarray(off, Math.min(off + maxChunk, ciphertext.length));
 			this.mem.set(chunk, ctOff);
-			this.x.cbcDecryptChunk_simd(chunk.length);
+			const ret = this.x.cbcDecryptChunk_simd(chunk.length);
+			if (ret < 0) throw new RangeError(
+				`cbcDecryptChunk_simd rejected len=${chunk.length}` +
+				` (WASM CHUNK_SIZE=${this.x.getChunkSize()})`,
+			);
 			output.set(new Uint8Array(this.x.memory.buffer).subarray(ptOff, ptOff + chunk.length), off);
 		}
 		return pkcs7Strip(output);

--- a/src/ts/stream/seal-stream-pool.ts
+++ b/src/ts/stream/seal-stream-pool.ts
@@ -158,6 +158,18 @@ export class SealStreamPool {
 			modules[required[0]] = await compileWasm(opts.wasm as WasmSource);
 		}
 
+		// For padded ciphers, validate that a full plaintext chunk fits in the WASM
+		// after PKCS7 padding. PKCS7 always adds between 1 and blockSize bytes.
+		if (cipher.padded) {
+			const paddedFull = chunkSize + 16 - (chunkSize % 16);
+			if (paddedFull > cipher.wasmChunkSize)
+				throw new RangeError(
+					`leviathan-crypto: chunkSize ${chunkSize} is too large for ${cipher.formatName} ` +
+					`(padded full chunk = ${paddedFull}, WASM CHUNK_SIZE = ${cipher.wasmChunkSize}). ` +
+					`Use chunkSize \u2264 ${cipher.wasmChunkSize - 1}.`,
+				);
+		}
+
 		if (key.length !== cipher.keySize)
 			throw new RangeError(`key must be ${cipher.keySize} bytes (got ${key.length})`);
 

--- a/src/ts/stream/types.ts
+++ b/src/ts/stream/types.ts
@@ -39,6 +39,7 @@ export interface CipherSuite {
 	readonly kemCtSize: number;           // 0 for symmetric; KEM ciphertext bytes otherwise
 	readonly tagSize: number;
 	readonly padded: boolean;
+	readonly wasmChunkSize: number;  // WASM CHUNK_SIZE constant; for padded ciphers, pool validates paddedFull <= this
 
 	deriveKeys(key: Uint8Array, nonce: Uint8Array, kemCt?: Uint8Array): DerivedKeys;
 

--- a/test/e2e/serpent_large_pool.spec.ts
+++ b/test/e2e/serpent_large_pool.spec.ts
@@ -1,0 +1,149 @@
+//                  ▄▄▄▄▄▄▄▄▄▄
+//           ▄████████████████████▄▄          ▒  ▄▀▀ ▒ ▒ █ ▄▀▄ ▀█▀ █ ▒ ▄▀▄ █▀▄
+//        ▄██████████████████████ ▀████▄      ▓  ▓▀  ▓ ▓ ▓ ▓▄▓  ▓  ▓▀▓ ▓▄▓ ▓ ▓
+//      ▄█████████▀▀▀     ▀███████▄▄███████▌  ▀▄ ▀▄▄ ▀▄▀ ▒ ▒ ▒  ▒  ▒ █ ▒ ▒ ▒ █
+//     ▐████████▀   ▄▄▄▄     ▀████████▀██▀█▌
+//     ████████      ███▀▀     ████▀  █▀ █▀       Leviathan Crypto Library
+//     ███████▌    ▀██▀         ███
+//      ███████   ▀███           ▀██ ▀█▄      Repository & Mirror:
+//       ▀██████   ▄▄██            ▀▀  ██▄    github.com/xero/leviathan-crypto
+//         ▀█████▄   ▄██▄             ▄▀▄▀    unpkg.com/leviathan-crypto
+//            ▀████▄   ▄██▄
+//              ▐████   ▐███                  Author: xero (https://x-e.ro)
+//       ▄▄██████████    ▐███         ▄▄      License: MIT
+//    ▄██▀▀▀▀▀▀▀▀▀▀     ▄████      ▄██▀
+//  ▄▀  ▄▄█████████▄▄  ▀▀▀▀▀     ▄███         This file is provided completely
+//   ▄██████▀▀▀▀▀▀██████▄ ▀▄▄▄▄████▀          free, "as is", and without
+//  ████▀    ▄▄▄▄▄▄▄ ▀████▄ ▀█████▀  ▄▄▄▄     warranty of any kind. The author
+//  █████▄▄█████▀▀▀▀▀▀▄ ▀███▄      ▄████      assumes absolutely no liability
+//   ▀██████▀             ▀████▄▄▄████▀       for its {ab,mis,}use.
+//                           ▀█████▀▀
+//
+import { test, expect } from '@playwright/test';
+
+const BASE = 'http://localhost:1337';
+
+test.beforeEach(async ({ page }) => {
+	await page.goto(BASE);
+});
+
+test.describe('SealStreamPool — Serpent large-chunk e2e', () => {
+
+	// 256 KB (4 full chunks at chunkSize=65536)
+	test('seal → open roundtrip at chunkSize: 65536, 256 KB (4 full chunks)', async ({ page }) => {
+		test.setTimeout(60_000);
+		const result = await page.evaluate(async (base) => {
+			const lib = await import(`${base}/dist/index.js`);
+			const { serpentWasm } = await import(`${base}/dist/serpent/embedded.js`);
+			const { sha2Wasm } = await import(`${base}/dist/sha2/embedded.js`);
+			lib._resetForTesting();
+			await lib.init({ serpent: serpentWasm, sha2: sha2Wasm });
+			const key = lib.randomBytes(32);
+			const pool = await lib.SealStreamPool.create(lib.SerpentCipher, key, {
+				wasm: { serpent: serpentWasm, sha2: sha2Wasm },
+				workers: 2,
+				chunkSize: 65536,
+			});
+			// counter pattern avoids crypto.getRandomValues 65536-byte limit
+			const pt = new Uint8Array(4 * 65536);
+			for (let i = 0; i < pt.length; i++) pt[i] = i & 0xff;
+			const ct = await pool.seal(pt);
+			const dec = await pool.open(ct);
+			pool.destroy();
+			return dec.length === pt.length
+				&& (dec as Uint8Array).every((b: number, i: number) => b === pt[i]);
+		}, BASE);
+		expect(result).toBe(true);
+	});
+
+	// 5 MB — compare SHA-256 hashes to avoid byte-for-byte comparison overhead
+	test('seal → open roundtrip at chunkSize: 65536, 5 MB (hash comparison)', async ({ page }) => {
+		test.setTimeout(120_000);
+		const result = await page.evaluate(async (base) => {
+			const lib = await import(`${base}/dist/index.js`);
+			const { serpentWasm } = await import(`${base}/dist/serpent/embedded.js`);
+			const { sha2Wasm } = await import(`${base}/dist/sha2/embedded.js`);
+			lib._resetForTesting();
+			await lib.init({ serpent: serpentWasm, sha2: sha2Wasm });
+
+			// Deterministic pseudorandom plaintext — LCG seeded at 0xdeadbeef
+			const N = 80 * 65536 + 23587; // 5266467 bytes
+			const pt = new Uint8Array(N);
+			let s = 0xdeadbeef >>> 0;
+			for (let i = 0; i < N; i++) {
+				s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+				pt[i] = s & 0xff;
+			}
+
+			const key = lib.randomBytes(32);
+			const pool = await lib.SealStreamPool.create(lib.SerpentCipher, key, {
+				wasm: { serpent: serpentWasm, sha2: sha2Wasm },
+				workers: 4,
+				chunkSize: 65536,
+			});
+			const ct = await pool.seal(pt);
+			const dec = await pool.open(ct);
+			pool.destroy();
+
+			const sha = new lib.SHA256();
+			const hashPt  = lib.bytesToHex(sha.hash(pt));
+			sha.dispose();
+			const sha2b = new lib.SHA256();
+			const hashDec = lib.bytesToHex(sha2b.hash(dec as Uint8Array));
+			sha2b.dispose();
+			return hashPt === hashDec;
+		}, BASE);
+		expect(result).toBe(true);
+	});
+
+	// Regression test for the pre-fix corruption: only the trailing partial chunk
+	// was correct; all full 65536-byte chunks decrypted to zeros.
+	test('all full chunks decrypt correctly, not just the trailing partial', async ({ page }) => {
+		test.setTimeout(60_000);
+		const result = await page.evaluate(async (base) => {
+			const lib = await import(`${base}/dist/index.js`);
+			const { serpentWasm } = await import(`${base}/dist/serpent/embedded.js`);
+			const { sha2Wasm } = await import(`${base}/dist/sha2/embedded.js`);
+			lib._resetForTesting();
+			await lib.init({ serpent: serpentWasm, sha2: sha2Wasm });
+
+			// 3 × 65536 = 196608 bytes — counter-byte pattern (0x00..0xFF repeating)
+			const N = 3 * 65536;
+			const pt = new Uint8Array(N);
+			for (let i = 0; i < N; i++) pt[i] = i & 0xff;
+
+			const key = lib.randomBytes(32);
+			const pool = await lib.SealStreamPool.create(lib.SerpentCipher, key, {
+				wasm: { serpent: serpentWasm, sha2: sha2Wasm },
+				workers: 2,
+				chunkSize: 65536,
+			});
+			const ct = await pool.seal(pt);
+			const dec = await pool.open(ct);
+			pool.destroy();
+
+			const d = dec as Uint8Array;
+			if (d.length !== N) return `length mismatch: ${d.length} !== ${N}`;
+
+			// Check first and last 32 bytes of each 65536-byte chunk
+			for (let chunk = 0; chunk < 3; chunk++) {
+				const chunkBase = chunk * 65536;
+				// First 32 bytes of this chunk
+				for (let j = 0; j < 32; j++) {
+					const expected = (chunkBase + j) & 0xff;
+					if (d[chunkBase + j] !== expected)
+						return `chunk ${chunk} byte ${j}: got ${d[chunkBase + j]}, want ${expected}`;
+				}
+				// Last 32 bytes of this chunk
+				for (let j = 65536 - 32; j < 65536; j++) {
+					const expected = (chunkBase + j) & 0xff;
+					if (d[chunkBase + j] !== expected)
+						return `chunk ${chunk} tail byte ${j}: got ${d[chunkBase + j]}, want ${expected}`;
+				}
+			}
+			return true;
+		}, BASE);
+		expect(result).toBe(true);
+	});
+
+});

--- a/test/unit/serpent/serpent_cbc.test.ts
+++ b/test/unit/serpent/serpent_cbc.test.ts
@@ -196,6 +196,89 @@ describe('SerpentCbc — IV sensitivity', () => {
 	});
 });
 
+// ── WASM chunk boundary ───────────────────────────────────────────────────
+
+describe('SerpentCbc — WASM chunk boundary', () => {
+	const key = new Uint8Array(32).fill(0x55);
+	const iv  = new Uint8Array(16).fill(0xAA);
+
+	function setupWasm() {
+		const wasm = getWasm();
+		const m = new Uint8Array(wasm.memory.buffer);
+		m.set(key, wasm.getKeyOffset());
+		wasm.loadKey(key.length);
+		m.set(iv, wasm.getCbcIvOffset());
+		return wasm;
+	}
+
+	it('cbcEncryptChunk succeeds at CHUNK_SIZE', () => {
+		const wasm = setupWasm();
+		const cs = wasm.getChunkSize(); // 65552 after fix
+		const m = new Uint8Array(wasm.memory.buffer);
+		for (let i = 0; i < cs; i++) m[wasm.getChunkPtOffset() + i] = i & 0xFF;
+		const ret = wasm.cbcEncryptChunk(cs);
+		expect(ret).toBe(cs);
+		// Real ciphertext — not all zeros, not plaintext
+		const ct0 = m.slice(wasm.getChunkCtOffset(), wasm.getChunkCtOffset() + 16);
+		expect(ct0.some(b => b !== 0)).toBe(true);
+		expect(ct0.every((b, i) => b === (i & 0xFF))).toBe(false);
+	}, 30_000);
+
+	it('cbcEncryptChunk rejects CHUNK_SIZE + 1', () => {
+		const wasm = setupWasm();
+		const cs = wasm.getChunkSize();
+		const m = new Uint8Array(wasm.memory.buffer);
+		// Fill the full CHUNK_PT_BUFFER; last 16 bytes are 0x10 (simulated PKCS7 padding)
+		for (let i = 0; i < cs - 16; i++) m[wasm.getChunkPtOffset() + i] = i & 0xFF;
+		for (let i = cs - 16; i < cs; i++) m[wasm.getChunkPtOffset() + i] = 0x10;
+		const ctBefore = m.slice(wasm.getChunkCtOffset(), wasm.getChunkCtOffset() + 16);
+		const ret = wasm.cbcEncryptChunk(cs + 1);
+		expect(ret).toBe(-1);
+		// Guard must return early — CHUNK_CT must be unchanged
+		const ctAfter = new Uint8Array(wasm.memory.buffer).slice(wasm.getChunkCtOffset(), wasm.getChunkCtOffset() + 16);
+		expect(Array.from(ctAfter)).toEqual(Array.from(ctBefore));
+	});
+
+	it('cbcDecryptChunk roundtrip at CHUNK_SIZE', () => {
+		const wasm = setupWasm();
+		const cs = wasm.getChunkSize();
+		const m = new Uint8Array(wasm.memory.buffer);
+		const original = new Uint8Array(cs);
+		for (let i = 0; i < cs; i++) original[i] = (i * 3) & 0xFF;
+		m.set(original, wasm.getChunkPtOffset());
+		const encRet = wasm.cbcEncryptChunk(cs);
+		expect(encRet).toBe(cs);
+		const ct = new Uint8Array(wasm.memory.buffer).slice(wasm.getChunkCtOffset(), wasm.getChunkCtOffset() + cs);
+		// Reset IV and decrypt
+		new Uint8Array(wasm.memory.buffer).set(iv, wasm.getCbcIvOffset());
+		new Uint8Array(wasm.memory.buffer).set(ct, wasm.getChunkCtOffset());
+		const decRet = wasm.cbcDecryptChunk(cs);
+		expect(decRet).toBe(cs);
+		const recovered = new Uint8Array(wasm.memory.buffer).slice(wasm.getChunkPtOffset(), wasm.getChunkPtOffset() + cs);
+		expect(Array.from(recovered)).toEqual(Array.from(original));
+	}, 30_000);
+
+	it('overflow guard: cbcEncryptChunk(CHUNK_SIZE) outputs real ciphertext, not [0x10]*16', () => {
+		// Regression guard for the pre-fix corruption mode:
+		// old CHUNK_SIZE=65536, old CHUNK_CT_OFFSET=66160. A 65552-byte write to
+		// CHUNK_PT_OFFSET(624) overflowed 16 bytes (66160..66175) into CHUNK_CT[0:16]
+		// with 0x10*16. cbcEncryptChunk(65552) returned -1 (rejected), leaving the
+		// overflow bytes in place as the "ciphertext". After fix: CHUNK_SIZE=65552,
+		// CHUNK_CT_OFFSET=66176 — no overlap; the call succeeds with real ciphertext.
+		const wasm = setupWasm();
+		const cs = wasm.getChunkSize();
+		const m = new Uint8Array(wasm.memory.buffer);
+		// Simulate a PKCS7-padded 65536-byte plaintext: last 16 bytes are 0x10
+		for (let i = 0; i < cs - 16; i++) m[wasm.getChunkPtOffset() + i] = i & 0xFF;
+		for (let i = cs - 16; i < cs; i++) m[wasm.getChunkPtOffset() + i] = 0x10;
+		const ret = wasm.cbcEncryptChunk(cs);
+		expect(ret).toBe(cs);
+		const ct0 = new Uint8Array(wasm.memory.buffer).slice(wasm.getChunkCtOffset(), wasm.getChunkCtOffset() + 16);
+		// Must be real ciphertext, not the PKCS7 overflow bytes
+		expect(ct0.every(b => b === 0x10)).toBe(false);
+	}, 30_000);
+});
+
 // ── RangeError for invalid key/IV sizes ──────────────────────────────────
 
 describe('SerpentCbc — parameter validation', () => {

--- a/test/unit/stream/pool.test.ts
+++ b/test/unit/stream/pool.test.ts
@@ -169,6 +169,94 @@ for (const cfg of configs) {
 				expect(dec).toEqual(pt);
 				pool.destroy();
 			});
+
+			// ── chunkSize=65536 boundary (Serpent-specific regression) ────
+
+			if (cfg.name === 'Serpent') {
+				it('chunkSize: 65536, single full chunk', async () => {
+					// Minimal reproducer for the pre-fix silent corruption bug:
+					// a 65536-byte plaintext padded to 65552 overflowed CHUNK_PT_BUFFER.
+					const pool = await SealStreamPool.create(cfg.cipher, key, {
+						wasm: cfg.wasm, workers: 1, chunkSize: 65536,
+					});
+					const pt = randomBytes(65536);
+					const ct = await pool.seal(pt);
+					const dec = await pool.open(ct);
+					expect(dec).toEqual(pt);
+					pool.destroy();
+				}, 30_000);
+
+				it('chunkSize: 65536, two full chunks', async () => {
+					const pool = await SealStreamPool.create(cfg.cipher, key, {
+						wasm: cfg.wasm, workers: 1, chunkSize: 65536,
+					});
+					// counter pattern avoids crypto.getRandomValues 65536-byte limit
+					const pt = new Uint8Array(131072);
+					for (let i = 0; i < pt.length; i++) pt[i] = i & 0xFF;
+					const ct = await pool.seal(pt);
+					const dec = await pool.open(ct);
+					expect(dec).toEqual(pt);
+					pool.destroy();
+				}, 60_000);
+
+				it('chunkSize: 65536, full chunks plus partial (5MB)', async () => {
+					// 80 × 65536 + 23587 = 5266467 bytes — covers all full-chunk
+					// and partial-chunk paths at production chunk size.
+					const pool = await SealStreamPool.create(cfg.cipher, key, {
+						wasm: cfg.wasm, workers: 2, chunkSize: 65536,
+					});
+					const n = 80 * 65536 + 23587;
+					const pt = new Uint8Array(n);
+					for (let i = 0; i < n; i++) pt[i] = (i * 3) & 0xFF;
+					const ct = await pool.seal(pt);
+					const dec = await pool.open(ct);
+					expect(dec).toEqual(pt);
+					pool.destroy();
+				}, 120_000);
+
+				it('chunkSize: 65536, exact multiple (3 × 65536)', async () => {
+					const pool = await SealStreamPool.create(cfg.cipher, key, {
+						wasm: cfg.wasm, workers: 1, chunkSize: 65536,
+					});
+					const pt = new Uint8Array(3 * 65536);
+					for (let i = 0; i < pt.length; i++) pt[i] = i & 0xFF;
+					const ct = await pool.seal(pt);
+					const dec = await pool.open(ct);
+					expect(dec).toEqual(pt);
+					pool.destroy();
+				}, 60_000);
+
+				it('create() rejects chunkSize that would overflow WASM CHUNK_SIZE after padding', async () => {
+					// chunkSize=65552: paddedFull = 65552 + 16 = 65568 > WASM CHUNK_SIZE (65552)
+					await expect(
+						SealStreamPool.create(cfg.cipher, key, {
+							wasm: cfg.wasm, workers: 1, chunkSize: 65552,
+						}),
+					).rejects.toThrow(/too large for serpent/i);
+				});
+
+				it('create() accepts chunkSize: 65536 (paddedFull = 65552 = WASM CHUNK_SIZE)', async () => {
+					const pool = await SealStreamPool.create(cfg.cipher, key, {
+						wasm: cfg.wasm, workers: 1, chunkSize: 65536,
+					});
+					pool.destroy();
+				});
+			}
+
+			if (cfg.name === 'XChaCha20') {
+				it('chunkSize: 65536, 131072 bytes (control — ChaCha20 is not padded)', async () => {
+					const pool = await SealStreamPool.create(cfg.cipher, key, {
+						wasm: cfg.wasm, workers: 1, chunkSize: 65536,
+					});
+					// counter pattern avoids crypto.getRandomValues 65536-byte limit
+					const pt = new Uint8Array(131072);
+					for (let i = 0; i < pt.length; i++) pt[i] = i & 0xFF;
+					const ct = await pool.seal(pt);
+					const dec = await pool.open(ct);
+					expect(dec).toEqual(pt);
+					pool.destroy();
+				}, 30_000);
+			}
 		});
 
 		// ── Auth failure ────────────────────────────────────────────────


### PR DESCRIPTION
## changes 
- fix for serpent streampools issue discovered when rebuilding the demo apps against v2.
  - bug: silent data corruption for inputs >= 65536 bytes via CBC buffer overflow
- new `npm-remove` workflow to unpublish or deprecate a previous version (i do this manually now).
  - rational: this is a crypto lib, and our fixes are almost always security related.